### PR TITLE
Properly deal with the Python modules provided by this module.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ env:
   matrix:
     
     - CONDA_PY=27
+    - CONDA_PY=35
+    - CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "tlNkpgU6wgk7+nnbJPh8z2kwt4HvGqchZJmPxwgJr0rh+mLnTw8V1HTTazfLyryk37/C6rKImd5FfBao1L4uvtdavsbhm0q5BaWLN+B2prBbxeosxRr1yb0yqn5hR68YwHIUCEiHD6XFgeSJzk1g6T1kQf0zcvTku5vZRYM70enkefaClR0ekrTnNn44MIiVPiffNI18JjY+27BDClScZLAUzJ501rmVGBewOqJ6cRY9Tpy+hM1kyScB/xbf5AH4Icfcz8QfSwcPf9RQicr/ZPsmZElVxhvCdeKlF79B81oEBVULmvnQOXQDQTXkCZuwDZAIjZoiG1ZcHUHd9EzDQmVwvcyC6IJYRGO2iUMo22tQew2WqgDhFRHKYQaX+BpPnygIWcfnh8CZHZRW9ZFV6AFIrrgHwCLmzb6eSyWq+4F6VPYnbc0lbodN6NEL0M5AmOpPbz17HOy0vhHzO9FBAWfkLe2Xipz2tWLtPnVrMnIWd8Yj8ka4OEDHRWio34VcxzwAkQtKquUi+iRE/5NzTraAlrqksoY40Gk6RphHH7qy6igGPMiPtfiBkZtN9hpaFHg2nzqtFUhzsI3r1Rx6WAVVn47yyKD+9pbUwbs9WFBLwlw/bQpj/GPc14FOYzcaLzwcUOC+A1ol7VKLdfHVRk02egiWd3WgIPHuZc6B6OE="

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,22 @@ environment:
       CONDA_PY: 27
       CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
+    - TARGET_ARCH: x86
+      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+
+    - TARGET_ARCH: x86
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the TARGET_ARCH variable.

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,9 +41,21 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 1 case(s).
+# Embarking on 3 case(s).
     set -x
     export CONDA_PY=27
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_PY=35
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_PY=36
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,20 +12,23 @@ source:
   fn: {{ name }}-{{ version }}.tar.bz2
   url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
   sha256: {{ sha256 }}
+  patches:
+    - python-35x-fixes.patch
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
-  skip: true  # [not py27]
 
 requirements:
   build:
     - m2w64-pkg-config  # [win]
     - pkg-config  # [not win]
     - posix  # [win]
-    - python >=2.7,<3
+    - python
     - toolchain
     - xorg-util-macros
+  run:
+    - python
 
 test:
   commands:

--- a/recipe/python-35x-fixes.patch
+++ b/recipe/python-35x-fixes.patch
@@ -1,0 +1,250 @@
+diff --git a/xcbgen/align.py b/xcbgen/align.py
+index 5e31838..d4c12ee 100644
+--- a/xcbgen/align.py
++++ b/xcbgen/align.py
+@@ -16,12 +16,12 @@ class Alignment(object):
+         return self.align == other.align and self.offset == other.offset
+ 
+     def __str__(self):
+-	return "(align=%d, offset=%d)" % (self.align, self.offset)
++        return "(align=%d, offset=%d)" % (self.align, self.offset)
+ 
+     @staticmethod
+     def for_primitive_type(size):
+-	# compute the required start_alignment based on the size of the type
+-	if size % 8 == 0:
++        # compute the required start_alignment based on the size of the type
++        if size % 8 == 0:
+             # do 8-byte primitives require 8-byte alignment in X11?
+             return Alignment(8,0)
+         elif size % 4 == 0:
+@@ -33,7 +33,7 @@ class Alignment(object):
+ 
+ 
+     def align_after_fixed_size(self, size):
+-	new_offset = (self.offset + size) % self.align
++        new_offset = (self.offset + size) % self.align
+         return Alignment(self.align, new_offset)
+ 
+ 
+@@ -41,7 +41,7 @@ class Alignment(object):
+         '''
+         Assuming the given external_align, checks whether
+         self is fulfilled for all cases.
+-	Returns True if yes, False otherwise.
++        Returns True if yes, False otherwise.
+         '''
+         if self.align == 1 and self.offset == 0:
+             # alignment 1 with offset 0 is always fulfilled
+@@ -55,9 +55,9 @@ class Alignment(object):
+             # the external align guarantees less alignment -> not guaranteed
+             return False
+ 
+-	if external_align.align % self.align != 0:
++        if external_align.align % self.align != 0:
+             # the external align cannot be divided by our align
+-	    # -> not guaranteed
++            # -> not guaranteed
+             # (this can only happen if there are alignments that are not
+             # a power of 2, which is highly discouraged. But better be
+             # safe and check for it)
+@@ -72,7 +72,7 @@ class Alignment(object):
+ 
+     def combine_with(self, other):
+         # returns the alignment that is guaranteed when
+-	# both, self or other, can happen
++        # both, self or other, can happen
+         new_align = gcd(self.align, other.align)
+         new_offset_candidate1 = self.offset % new_align
+         new_offset_candidate2 = other.offset % new_align
+@@ -83,8 +83,8 @@ class Alignment(object):
+             new_align = gcd(new_align, offset_diff)
+             new_offset_candidate1 = self.offset % new_align
+             new_offset_candidate2 = other.offset % new_align
+-	    assert new_offset_candidate1 == new_offset_candidate2
+-	    new_offset = new_offset_candidate1
++            assert new_offset_candidate1 == new_offset_candidate2
++            new_offset = new_offset_candidate1
+         # return the result
+         return Alignment(new_align, new_offset)
+ 
+@@ -92,44 +92,44 @@ class Alignment(object):
+ class AlignmentLog(object):
+ 
+     def __init__(self):
+-	self.ok_list = []
+-	self.fail_list = []
+-	self.verbosity = 1
++        self.ok_list = []
++        self.fail_list = []
++        self.verbosity = 1
+ 
+     def __str__(self):
+-	result = ""
++        result = ""
+ 
+-	# output the OK-list
+-	for (align_before, field_name, type_obj, callstack, align_after) in self.ok_list:
+-	    stacksize = len(callstack)
++        # output the OK-list
++        for (align_before, field_name, type_obj, callstack, align_after) in self.ok_list:
++            stacksize = len(callstack)
+             indent = '  ' * stacksize
+-	    if self.ok_callstack_is_relevant(callstack):
++            if self.ok_callstack_is_relevant(callstack):
+                 if field_name is None or field_name == "":
+-	            result += ("    %sok: %s:\n\t%sbefore: %s, after: %s\n"
+-		        % (indent, str(type_obj), indent, str(align_before), str(align_after)))
+-	        else:
+-		    result += ("    %sok: field \"%s\" in %s:\n\t%sbefore: %s, after: %s\n"
+-		        % (indent, str(field_name), str(type_obj),
+-		           indent, str(align_before), str(align_after)))
++                    result += ("    %sok: %s:\n\t%sbefore: %s, after: %s\n"
++                        % (indent, str(type_obj), indent, str(align_before), str(align_after)))
++                else:
++                    result += ("    %sok: field \"%s\" in %s:\n\t%sbefore: %s, after: %s\n"
++                        % (indent, str(field_name), str(type_obj),
++                           indent, str(align_before), str(align_after)))
+                 if self.verbosity >= 1:
+-		    result += self.callstack_to_str(indent, callstack)
++                    result += self.callstack_to_str(indent, callstack)
+ 
+-	# output the fail-list
+-	for (align_before, field_name, type_obj, callstack, reason) in self.fail_list:
+-	    stacksize = len(callstack)
++        # output the fail-list
++        for (align_before, field_name, type_obj, callstack, reason) in self.fail_list:
++            stacksize = len(callstack)
+             indent = '  ' * stacksize
+-	    if field_name is None or field_name == "":
+-	        result += ("    %sfail: align %s is incompatible with\n\t%s%s\n\t%sReason: %s\n"
+-		    % (indent, str(align_before), indent, str(type_obj), indent, reason))
+-	    else:
+-		result += ("    %sfail: align %s is incompatible with\n\t%sfield \"%s\" in %s\n\t%sReason: %s\n"
+-		    % (indent, str(align_before), indent, str(field_name), str(type_obj), indent, reason))
++            if field_name is None or field_name == "":
++                result += ("    %sfail: align %s is incompatible with\n\t%s%s\n\t%sReason: %s\n"
++                    % (indent, str(align_before), indent, str(type_obj), indent, reason))
++            else:
++                result += ("    %sfail: align %s is incompatible with\n\t%sfield \"%s\" in %s\n\t%sReason: %s\n"
++                    % (indent, str(align_before), indent, str(field_name), str(type_obj), indent, reason))
+ 
+             if self.verbosity >= 1:
+-	        result += self.callstack_to_str(indent, callstack)
++                result += self.callstack_to_str(indent, callstack)
+ 
+ 
+-	return result
++        return result
+ 
+ 
+     def callstack_to_str(self, indent, callstack):
+@@ -137,41 +137,41 @@ class AlignmentLog(object):
+         for stack_elem in callstack:
+             result += "\t  %s%s\n" % (indent, str(stack_elem))
+         result += "\t%s]\n" % indent
+-	return result
++        return result
+ 
+ 
+     def ok_callstack_is_relevant(self, ok_callstack):
+         # determine whether an ok callstack is relevant for logging
+-	if self.verbosity >= 2:
+-	    return True
++        if self.verbosity >= 2:
++            return True
+ 
+         # empty callstacks are always relevant
+-	if len(ok_callstack) == 0:
++        if len(ok_callstack) == 0:
+             return True
+ 
+-	# check whether the ok_callstack is a subset or equal to a fail_callstack
++        # check whether the ok_callstack is a subset or equal to a fail_callstack
+         for (align_before, field_name, type_obj, fail_callstack, reason) in self.fail_list:
+             if len(ok_callstack) <= len(fail_callstack):
+                 zipped = zip(ok_callstack, fail_callstack[:len(ok_callstack)])
+-		is_subset = all([i == j for i, j in zipped])
+-		if is_subset:
++                is_subset = all([i == j for i, j in zipped])
++                if is_subset:
+                     return True
+ 
+         return False
+ 
+ 
+     def ok(self, align_before, field_name, type_obj, callstack, align_after):
+-	self.ok_list.append((align_before, field_name, type_obj, callstack, align_after))
++        self.ok_list.append((align_before, field_name, type_obj, callstack, align_after))
+ 
+     def fail(self, align_before, field_name, type_obj, callstack, reason):
+-	self.fail_list.append((align_before, field_name, type_obj, callstack, reason))
++        self.fail_list.append((align_before, field_name, type_obj, callstack, reason))
+ 
+     def append(self, other):
+-	self.ok_list.extend(other.ok_list)
+-	self.fail_list.extend(other.fail_list)
++        self.ok_list.extend(other.ok_list)
++        self.fail_list.extend(other.fail_list)
+ 
+     def ok_count(self):
+-	return len(self.ok_list)
++        return len(self.ok_list)
+ 
+ 
+ 
+diff --git a/xcbgen/xtypes.py b/xcbgen/xtypes.py
+index c3b5758..b83b119 100644
+--- a/xcbgen/xtypes.py
++++ b/xcbgen/xtypes.py
+@@ -501,7 +501,7 @@ class ComplexType(Type):
+                 int(required_start_align_element.get('align', "4"), 0),
+                 int(required_start_align_element.get('offset', "0"), 0))
+             if verbose_align_log:
+-                print "Explicit start-align for %s: %s\n" % (self, self.required_start_align)
++                print ("Explicit start-align for %s: %s\n" % (self, self.required_start_align))
+ 
+     def resolve(self, module):
+         if self.resolved:
+@@ -592,7 +592,7 @@ class ComplexType(Type):
+                 if verbose_align_log:
+                     print ("calc_required_start_align: %s has start-align %s"
+                         % (str(self), str(self.required_start_align)))
+-                    print "Details:\n" + str(log)
++                    print ("Details:\n" + str(log))
+                 if self.required_start_align.offset != 0:
+                     print (("WARNING: %s\n\thas start-align with non-zero offset: %s"
+                         + "\n\tsuggest to add explicit definition with:"
+@@ -619,12 +619,12 @@ class ComplexType(Type):
+             for offset in range(0,align):
+                 align_candidate = Alignment(align, offset)
+                 if verbose_align_log:
+-                    print "trying %s for %s" % (str(align_candidate), str(self))
++                    print ("trying %s for %s" % (str(align_candidate), str(self)))
+                 my_log = AlignmentLog()
+                 if self.is_possible_start_align(align_candidate, callstack, my_log):
+                     log.append(my_log)
+                     if verbose_align_log:
+-                        print "found start-align %s for %s" % (str(align_candidate), str(self))
++                        print ("found start-align %s for %s" % (str(align_candidate), str(self)))
+                     return align_candidate
+                 else:
+                     my_ok_count = my_log.ok_count()
+@@ -641,7 +641,7 @@ class ComplexType(Type):
+         # none of the candidates applies
+         # this type has illegal internal aligns for all possible start_aligns
+         if verbose_align_log:
+-            print "didn't find start-align for %s" % str(self)
++            print ("didn't find start-align for %s" % str(self))
+         log.append(best_log)
+         return None
+ 
+@@ -900,7 +900,7 @@ class SwitchType(ComplexType):
+     # aux function for unchecked_get_alignment_after
+     def get_align_for_selected_case_field(self, case_field, start_align, callstack, log):
+         if verbose_align_log:
+-            print "get_align_for_selected_case_field: %s, case_field = %s" % (str(self), str(case_field))
++            print ("get_align_for_selected_case_field: %s, case_field = %s" % (str(self), str(case_field)))
+         total_align = start_align
+         for field in self.bitcases:
+             my_callstack = callstack[:]


### PR DESCRIPTION
They are installed and used by dependent packages, so we have to matrix over Python versions and add Python as a run-time dependency.

This introduces the problem that the code is not compatible with Python 3.x. Fortunately, Arch Linux has a patch to make things happy. I've imported their 'python-35x-fixes.patch', from their commit 5b22f6811f92c: [this URL](https://git.archlinux.org/svntogit/packages.git/tree/trunk/python-35x-fixes.patch?h=packages/xcb-proto).