### PR TITLE
Fix the Python installation location on Windows.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,9 +15,10 @@ source:
   sha256: {{ sha256 }}
   patches:
     - python-35x-fixes.patch
+    - windows-pythondir.patch  # [win]
 
 build:
-  number: 2
+  number: 3
   detect_binary_files_with_prefix: true
 
 requirements:
@@ -36,6 +37,8 @@ requirements:
     - python
 
 test:
+  imports:
+    - xcbgen
   commands:
     - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
     - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]

--- a/recipe/windows-pythondir.patch
+++ b/recipe/windows-pythondir.patch
@@ -1,0 +1,10 @@
+--- configure.ac.orig	2017-02-04 17:17:00.583752530 -0500
++++ configure.ac	2017-02-04 17:17:54.347995984 -0500
+@@ -15,6 +15,7 @@
+ fi
+ 
+ AM_PATH_PYTHON([2.5])
++pythondir="$(cd $PREFIX/Lib/site-packages && pwd -W)"
+ 
+ xcbincludedir='${datadir}/xcb'
+ AC_SUBST(xcbincludedir)


### PR DESCRIPTION
The Windows Python interpreters seem to have their modules installed in a strange location that doesn't match up with the directory that the AM_PATH_PYTHON detects. Just override it manually.